### PR TITLE
Add Setting to Toggle Volume Sliders

### DIFF
--- a/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/model/HomeViewModel.kt
+++ b/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/model/HomeViewModel.kt
@@ -1,5 +1,6 @@
 /**
  *    Copyright 2022-2023 mkckr0 <https://github.com/mkckr0>
+ *    Copyright 2023 CamarataM <https://github.com/CamarataM>
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -78,14 +79,14 @@ class HomeViewModel(private val application: Application) : AndroidViewModel(app
 
     fun onWorkVolumeChange(value: Int) {
         workVolume.value = value
-        if (isPlaying.value!!) {
+        if (sharedPreferences.getBoolean("audio_use_volume_sliders", true) && isPlaying.value!!) {
             audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, value, 0)
         }
     }
 
     fun onIdleVolumeChange(value: Int) {
         idleVolume.value = value
-        if (!isPlaying.value!!) {
+        if (sharedPreferences.getBoolean("audio_use_volume_sliders", true) && !isPlaying.value!!) {
             audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, value, 0)
         }
     }
@@ -136,12 +137,16 @@ class HomeViewModel(private val application: Application) : AndroidViewModel(app
         override fun onAudioStop() {
             isPlaying.value = false
             info.value = application.getString(R.string.audio_stopped)
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, idleVolume.value!!, 0)
+            if (sharedPreferences.getBoolean("audio_use_volume_sliders", true)) {
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, idleVolume.value!!, 0)
+            }
         }
 
         override fun onAudioStart() {
             info.value = application.getString(R.string.audio_started)
-            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, workVolume.value!!, 0)
+            if (sharedPreferences.getBoolean("audio_use_volume_sliders", true)) {
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, workVolume.value!!, 0)
+            }
         }
     }
 }

--- a/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/HomeFragment.kt
+++ b/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/HomeFragment.kt
@@ -1,5 +1,6 @@
 /**
  *    Copyright 2022-2023 mkckr0 <https://github.com/mkckr0>
+*    Copyright 2023 CamarataM <https://github.com/CamarataM>
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -69,14 +70,18 @@ class HomeFragment : Fragment() {
         binding.viewModel = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
 
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        
         binding.sliderWorkVolume.addOnSliderTouchListener(VolumeSliderTouchListener())
         binding.sliderWorkVolume.addOnChangeListener { _, value, _ ->
             viewModel.onWorkVolumeChange(value.toInt())
         }
+        binding.sliderWorkVolume.isEnabled = sharedPreferences.getBoolean("audio_use_volume_sliders", true)
         binding.sliderIdleVolume.addOnSliderTouchListener(VolumeSliderTouchListener())
         binding.sliderIdleVolume.addOnChangeListener { _, value, _ ->
             viewModel.onIdleVolumeChange(value.toInt())
         }
+        binding.sliderIdleVolume.isEnabled = sharedPreferences.getBoolean("audio_use_volume_sliders", true)
 
         viewModel.hostError.observe(viewLifecycleOwner) { binding.textFieldHostLayout.error = it }
         viewModel.portError.observe(viewLifecycleOwner) { binding.textFieldPortLayout.error = it }

--- a/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/HomeFragment.kt
+++ b/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/HomeFragment.kt
@@ -1,6 +1,6 @@
 /**
  *    Copyright 2022-2023 mkckr0 <https://github.com/mkckr0>
-*    Copyright 2023 CamarataM <https://github.com/CamarataM>
+ *    Copyright 2023 CamarataM <https://github.com/CamarataM>
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/SettingsFragment.kt
+++ b/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/SettingsFragment.kt
@@ -1,5 +1,6 @@
 /**
  *    Copyright 2022-2023 mkckr0 <https://github.com/mkckr0>
+ *    Copyright 2023 CamarataM <https://github.com/CamarataM>
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -56,6 +57,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 it.setSelection(it.length())
             }
             setSummaryProvider { "${(it as EditTextPreference).text}ms" }
+        }
+        findPreference<SwitchPreference>("audio_use_volume_sliders")!!.apply {
+            isEnabled = true
         }
 
         updateRequestIgnoreBatteryOptimizations()

--- a/android-app/app/src/main/res/drawable/baseline_volume_up.xml
+++ b/android-app/app/src/main/res/drawable/baseline_volume_up.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="36dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,9v6h4l5,5L12,4L7,9L3,9zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/android-app/app/src/main/res/xml/root_preferences.xml
+++ b/android-app/app/src/main/res/xml/root_preferences.xml
@@ -1,5 +1,6 @@
 <!--
    Copyright 2022-2023 mkckr0 <https://github.com/mkckr0>
+   Copyright 2023 CamarataM <https://github.com/CamarataM>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,6 +32,13 @@
             app:icon="@drawable/baseline_timer_3"
             app:defaultValue="@string/audio_tcp_connect_timeout"
             tools:summary="3000ms" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:title="Use Volume Sliders"
+            app:icon="@drawable/baseline_volume_up"
+            app:key="audio_use_volume_sliders" />
     </PreferenceCategory>
 
     <PreferenceCategory app:title="Battery Optimization">


### PR DESCRIPTION
The application suits my needs perfectly, but would mess with my audio settings in Android when idle, which for me are different for when I have headphones in and when I do not. At the OS level, my volume is set to 50% when I have my headphones plugged in but 0% when I don't have headphones in. When I would idle the application without headphones plugged in, my OS volume settings would be overwritten by audio-share, which is undesirable for my use case. This PR adds a toggle in the settings menu which disables the volume control functionality, allowing for the volume control to be controlled exclusively by the operating system both when headphones are plugged in and when not.

Feel free to merge my changes, implement them yourself in your own way, or neither. Regardless, thank you for making this program.