### PR TITLE
server-core: Add CMake option for static linking with libstdc++

### DIFF
--- a/server-core/CMakeLists.txt
+++ b/server-core/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+option(AUDIO_SHARE_STATIC_LIBCPP "Link statically with standard c++ library" ON)
+
 set(AUDIO_SHARE_BIN_NAME "as-cmd")
 configure_file(src/config.h.in config.h)
 
@@ -42,9 +44,9 @@ add_executable(server-cmd
 	"src/main.cpp"
 )
 set_target_properties(server-cmd PROPERTIES OUTPUT_NAME ${AUDIO_SHARE_BIN_NAME})
-if(UNIX)
+if(AUDIO_SHARE_STATIC_LIBCPP AND UNIX)
 	target_link_options(server-cmd PRIVATE "-static-libstdc++")
-endif(UNIX)
+endif(AUDIO_SHARE_STATIC_LIBCPP AND UNIX)
 
 find_package(asio CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)

--- a/server-core/CMakeLists.txt
+++ b/server-core/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-option(AUDIO_SHARE_STATIC_LIBCPP "Link statically with standard c++ library" ON)
+option(AUDIO_SHARE_STATIC_LIBCPP "Link statically with standard C++ library (Only for Linux)" ON)
 
 set(AUDIO_SHARE_BIN_NAME "as-cmd")
 configure_file(src/config.h.in config.h)
@@ -46,7 +46,7 @@ add_executable(server-cmd
 set_target_properties(server-cmd PROPERTIES OUTPUT_NAME ${AUDIO_SHARE_BIN_NAME})
 if(AUDIO_SHARE_STATIC_LIBCPP AND UNIX)
 	target_link_options(server-cmd PRIVATE "-static-libstdc++")
-endif(AUDIO_SHARE_STATIC_LIBCPP AND UNIX)
+endif()
 
 find_package(asio CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)


### PR DESCRIPTION
This allows to select whether to link with libstdc++ statically or not. Also, some systems do not provide libstdc++ by default.