### PR TITLE
【Server Core Audio Client On Win】【WIP】feat: add server core audio client for windows

### DIFF
--- a/server-core/CMakePresets.json
+++ b/server-core/CMakePresets.json
@@ -27,7 +27,9 @@
             "name": "windows-Debug",
             "inherits": "windows-base",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+              "CMAKE_BUILD_TYPE": "Debug",
+              "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+              "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDebug"
             }
         },
         {

--- a/server-core/src/audio_manager.hpp
+++ b/server-core/src/audio_manager.hpp
@@ -82,6 +82,11 @@ public:
     void start_loopback_recording(std::shared_ptr<network_manager> network_manager, const capture_config& config);
     void stop();
     void do_loopback_recording(std::shared_ptr<network_manager> network_manager, const capture_config& config);
+    
+    void audio_init(AudioFormat& format);
+    void audio_start();
+    void audio_play(const std::vector<char>& buffer);
+    void audio_stop();
 
     std::string get_format_binary();
 

--- a/server-core/src/linux/audio_manager_impl.cpp
+++ b/server-core/src/linux/audio_manager_impl.cpp
@@ -421,4 +421,19 @@ std::string audio_manager::get_default_endpoint()
     return user_data.default_id;
 }
 
+void audio_manager::audio_init(AudioFormat& format)
+{
+    spdlog::error("not implement");
+}
+
+void audio_manager::audio_start()
+{
+    spdlog::error("not implement");
+}
+
+void audio_manager::audio_play(const std::vector<char>& buffer)
+{
+    spdlog::error("not implement");
+}
+
 #endif // linux

--- a/server-core/src/network_manager.hpp
+++ b/server-core/src/network_manager.hpp
@@ -64,6 +64,9 @@ public:
     void start_server(const std::string& host, uint16_t port, const audio_manager::capture_config& capture_config);
     void stop_server();
     void wait_server();
+    void start_client(const std::string& host, uint16_t port);
+    void stop_client();
+    void wait_client();
     bool is_running() const;
 
 private:
@@ -71,7 +74,10 @@ private:
     asio::awaitable<void> read_loop(std::shared_ptr<tcp_socket> peer);
     asio::awaitable<void> heartbeat_loop(std::shared_ptr<tcp_socket> peer);
     asio::awaitable<void> accept_udp_loop();
-    
+    asio::awaitable<void> client_connect(std::shared_ptr<network_manager> self, const std::string host, uint16_t port);
+    asio::awaitable<void> client_heartbeat_loop(std::shared_ptr<tcp_socket> socket);
+    asio::awaitable<void> client_udp_loop(audio_manager::AudioFormat audio_format, const std::string host, uint16_t port, uint32_t id);
+
     playing_peer_list_t::iterator close_session(std::shared_ptr<tcp_socket>& peer);
     int add_playing_peer(std::shared_ptr<tcp_socket>& peer);
     playing_peer_list_t::iterator remove_playing_peer(std::shared_ptr<tcp_socket>& peer);


### PR DESCRIPTION
---
English Version

This is a flawed PR. I feel that it's quite challenging for me to tackle the last problem on my own, so I've opened this PR to ask for help.

I've spent approximately three weeks of my free time on this. During the implementation process, I've resolved the following issues:

- [x] Enabled the client (Windows) to play sounds. By utilizing the `pAudioClient->SetEventHandle(hEvent)` event, I addressed the problem where CPU usage during playback reached up to `12%`.
- [x] Solved the problem of inconsistent audio format support between the server and the client. I used the `pAudioClient->IsFormatSupported` method to achieve comparable playback.
- [x] Resolved the issue where some hosts support audio playback objects in the `WAVEFORMATEX` format while others support the `WAVEFORMATEXTENSIBLE` format.
- [x] Added a ring buffer to deal with the issue that the UDP audio data received each time is too small (around a maximum of 1490 bytes).
- [x] Conducted basic studies on the asio await mode and MFC.

In the end, there's still one problem remaining:

- [ ] The data received via UDP is actually faster than the audio playback speed, causing the played sound to lag behind the real - time sound.

The efforts I've made are as follows:
1. Added a ring buffer to discard data when buffer overflow occurs. However, this doesn't solve the problem of sound delay.

---
中文版本（Chinese Version）

这是1个有缺陷的PR，最后的一个问题我感觉只凭我自己难以处理了，所以才开启这个PR，以寻求帮助。

我大概花了3周的业余时间，在实现的过程中解决了如下问题：

- [x] 添加 client(windows) 播放声音能力，使用 `pAudioClient->SetEventHandle(hEvent)` 事件，解决播放过程占用 CPU 高达 `12%` 的问题。
- [x] 解决 server和client 支持音频格式不一致问题，使用接近的播放 `pAudioClient->IsFormatSupported`。
- [x] 解决有的主机支持的音频播放对象是  `WAVEFORMATEX` 格式，而有的是 `WAVEFORMATEXTENSIBLE` 的问题。
- [x] 添加 ringbuffer 缓存 udp 音频数据每次 recv 数据太小的问题（约最大1490）。
- [x] asio await 模式入门学习、MFC 入门学习。

最终剩余下1个问题：

- [ ] udp 接收的数据，实际上比播放音频的速度要快，导致播放的声音落后于实时的声音。

我做出的努力如下：
1. 添加 ringbuffer 丢弃缓冲溢出的数据。但是这不能解决声音延时的问题。