### PR TITLE
Fixes to the audio screen accessibility 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+android-app/keystore.jks
+android-app/app/keystore.jks

--- a/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/base/Config.kt
+++ b/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/base/Config.kt
@@ -32,12 +32,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.isTraceInProgress
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
@@ -49,7 +55,12 @@ import kotlinx.coroutines.launch
 fun ConfigGroup(title: String, content: @Composable () -> Unit) {
     OutlinedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(16.dp).semantics(
+                mergeDescendants = true
+            ){
+                isTraversalGroup = true
+                traversalIndex = 1f
+            },
         ) {
             Text(
                 text = title,
@@ -110,7 +121,9 @@ fun SliderConfig(
                 track = {
                     SliderDefaults.Track(it, drawTick = { _, _ -> })
                 },
-                modifier = Modifier.padding(top = 4.dp, start = 2.dp, end = 2.dp),
+                modifier = Modifier.padding(top = 4.dp, start = 2.dp, end = 2.dp).semantics {
+                    contentDescription = "$title " + valueFormatter(tempValue)
+                },
             )
         }
     }

--- a/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/base/Config.kt
+++ b/android-app/app/src/main/java/io/github/mkckr0/audio_share_app/ui/base/Config.kt
@@ -32,14 +32,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.isTraceInProgress
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics


### PR DESCRIPTION
## Summary
The following request fixes the issue #157. I wasn’t sure whether the intent was to group the entire container or just the text and slider, but grouping the whole container made the most sense since TalkBack reads the entire container.

## Changes
- Added `mergeDescendants = true` to `ConfigGroup.OutlinedCard.Column`
- Sets `Column` to be the first traversal in the group followed by the sliders
- Added `contentDescription` to Column `Text` to include the title and proper value

<img width="360" height="800" alt="Screenshot_20250812_125751" src="https://github.com/user-attachments/assets/e21c1923-7fb4-4ad0-b071-d1bda424f6ac" />
